### PR TITLE
Add SkyLink API

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ An interesting intersection of aviation and technology for someone who likes to 
 * [Stratux ADS-B | Stratux ADS-B - DIY/Low-cost Portable ADS-B](http://stratux.me/)
 * [What’s the difference between 1090 and 978? - Cincinnati Avionics](https://cincinnatiavionics.com/ads-b-out-difference-1090-978/)
 * [ADSBexchange.com](https://www.adsbexchange.com/) - Unfiltered ADS-B data aggregator.
+* [SkyLink API](https://skylinkapi.com/) - All-in-one aviation REST API with live ADS-B traffic, aerodrome charts for 90+ countries, NOTAMs, carbon estimates, and flight-time prediction.
 * [dump1090](https://github.com/antirez/dump1090) - Open-source ADS-B decoder.
 
 # Simulation


### PR DESCRIPTION
Adds SkyLink API under Tech Stuff > DIY / Maker, next to the other data
sources (OpenSky, ADSBexchange, dump1090).

It's an aviation REST API that pulls a few things into one place: live
ADS-B traffic, aerodrome charts for 90+ countries, NOTAMs, per-flight
carbon estimates, and flight-time prediction, plus the usual aircraft,
airline and airport reference data. Figured it fits the maker/tinkerer
crowd that's already using the ADS-B tools on the list, and the charts
and carbon endpoints cover a couple of things I didn't see anything for
yet. There's a free tier so people can try it on hobby projects.

Left it untagged to match the list style (kept the ($$) convention in
mind but it has a free tier). Happy to move it or adjust the wording if
you'd rather it sit somewhere else.