### PR TITLE
Add PPL Free Ground School to Educational Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Want to learn to fly?
   * [Real World VFR](https://pilotworkshop.com/products/real-world-vfr/) - Fantastic edutainment.
   * [Pilot Workshop Weekly Tips](https://pilotworkshop.com/tips)
 * [MzeroA](https://www.mzeroa.com/) - Online ground school.
+* [PPL Free Ground School](https://pplfree.com) - Free FAA Private Pilot ground school: 22 modules, 872 practice questions, unlimited FAA-format mock exams. Free permanently, no card.
 * [FAA Safety](https://www.faasafety.gov/) -  Particularly their WINGS program.
 * ⭐[AOPA Online Courses](https://www.aopa.org/training-and-safety/online-learning/online-courses)
   * [Rusty Pilots Online - AOPA](https://www.aopa.org/training-and-safety/lapsed-pilots/rusty-pilots/rusty-pilots-online)


### PR DESCRIPTION
Adds [PPL Free Ground School](https://pplfree.com) to the Educational Resources section, alongside the other ground-school entries.

**Disclosure: I'm the founder** (OB), so judge accordingly — but the listing claim is verifiable in two clicks: the complete FAA Private Pilot ground school is free with no card and no trial (22 modules, 872 practice questions, unlimited 60-question/2h30 FAA-format mock exams). Every lesson is readable without an account.

Honest caveats, stated on the site itself: not FAA-approved or affiliated; content is reviewed through an AI instructional-review system, not a certificated flight instructor; the optional $99 completion certificate is a course-completion record, not an FAA credential; no endorsements issued.

Happy to adjust the wording or placement to fit the list's conventions.