### PR TITLE
Add safety-data explorers and accident-report scrapers to Safety section

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ An interesting intersection of aviation and technology for someone who likes to 
 * [Aviation Safety Reporting System (ASRS)](https://asrs.arc.nasa.gov/) - NASA's confidential voluntary reporting system. Learn from incidents reported by pilots, controllers, and others.
 * [AVweb](https://www.avweb.com/) - Aviation news and analysis, including accident coverage and safety articles.
 * [FAA Accident & Incident Data](https://www.asias.faa.gov/) - FAA's Aviation Safety Information Analysis and Sharing system.
+* [FlightFinder Safety Data](https://himaxym.com/safety) - Free explorers over public safety datasets: FAA wildlife strikes (347K reports), laser strikes, drone sightings, ASRS incident narratives, runway incursions and accident histories.
+* [aviation-safety-scrapers](https://github.com/disclaimer8/aviation-safety-scrapers) - Open-source scrapers for 38 national accident-investigation agencies (NTSB, AAIB, BEA, BFU, ATSB and others).
 
 # Medical / AME
 * [FAA MedXPress](https://medxpress.faa.gov/) - Online application system for FAA medical certificates.


### PR DESCRIPTION
Two additions to Safety & Accident Investigation:

- **FlightFinder Safety Data** (https://himaxym.com/safety) — free interactive explorers over public datasets: FAA wildlife strikes (347K reports, also released as versioned CC-BY CSVs on Zenodo: https://doi.org/10.5281/zenodo.21347859), laser strikes, drone sightings, ASRS narratives, runway incursions and accident histories.
- **aviation-safety-scrapers** (https://github.com/disclaimer8/aviation-safety-scrapers) — Apache-2.0-licensed scrapers for 38 national accident-investigation agencies (NTSB, AAIB, BEA, BFU, ATSB and others).

Disclosure: both are my projects — happy to adjust wording or drop either if they don't fit the list's bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)